### PR TITLE
Node-sass Revert

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "index.js"
   ],
   "dependencies": {
-    "node-sass": "1.2.3"
+    "node-sass": "1.1.4"
   },
   "bugs": {
     "url": "https://github.com/kasperlewau/koa-sass/issues"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "index.js"
   ],
   "dependencies": {
-    "node-sass": "1.1.4"
+    "node-sass": "0.9.6"
   },
   "bugs": {
     "url": "https://github.com/kasperlewau/koa-sass/issues"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "index.js"
   ],
   "dependencies": {
-    "node-sass": "latest"
+    "node-sass": "1.2.3"
   },
   "bugs": {
     "url": "https://github.com/kasperlewau/koa-sass/issues"


### PR DESCRIPTION
The latest version of of node-sass was throwing errors when installing on Linux. Reverting to version 1.4.4 fixes this problem.
